### PR TITLE
refactor: watchtower auto clean

### DIFF
--- a/roles/docker_setup/tasks/watchtower.yml
+++ b/roles/docker_setup/tasks/watchtower.yml
@@ -6,4 +6,6 @@
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: --interval 43200
+    env:
+      WATCHTOWER_CLEANUP: 'true'
     restart_policy: always


### PR DESCRIPTION
# Description

A change to Watchertower's docker-compose file to auto cleanup old images. This is so I don't have to cleanup unused docker images manually after I notice the filesystem starts to grow in size.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been run against my local server, and does as describes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
